### PR TITLE
add wss-wu-dryville.jpg as an untracked file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wss-wu-dryville.jpg


### PR DESCRIPTION
## Premise
Added banner from the [USGS Water Science School](https://www.usgs.gov/special-topic/water-science-school/science/story-water-dryville?qt-science_center_objects=0#qt-science_center_objects) page directly to the local gitflow repository folder. As an untracked file, it was added to the gitignore file (Refer to #16). 
